### PR TITLE
fix: renamed input arguments to conform with terminology

### DIFF
--- a/src/autora/theorist/example_theorist/__init__.py
+++ b/src/autora/theorist/example_theorist/__init__.py
@@ -23,8 +23,8 @@ class ExampleRegressor(BaseEstimator):
     def __init__(self):
         pass
 
-    def fit(self, x, y):
+    def fit(self, conditions, observations):
         pass
 
-    def predict(self, x):
+    def predict(self, conditions):
         pass


### PR DESCRIPTION
Simple renamings from x --> conditions, and y --> observations